### PR TITLE
feat: Translate commands to English (misc/englishlanguage)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = 'de.project_minecraft'
-version = '1.1 rev-3'
+version = '1.1 rev-4'
 
 jar {
     archiveBaseName = 'DiscordCommand'  // Der Name der generierten .jar-Datei

--- a/src/main/java/de/project_minecraft/commandDiscord/commands/DiscordCommand.java
+++ b/src/main/java/de/project_minecraft/commandDiscord/commands/DiscordCommand.java
@@ -38,7 +38,7 @@ public class DiscordCommand implements CommandExecutor {
             return new HelpCommand(plugin).onCommand(sender, command, label, args);
         }
 
-        sender.sendMessage("§cUnbekannter Unterbefehl! Verwende: /discord help");
+        sender.sendMessage("§cUnknown command! Use: /discord help");
         return false;
     }
 }

--- a/src/main/java/de/project_minecraft/commandDiscord/commands/EditCommand.java
+++ b/src/main/java/de/project_minecraft/commandDiscord/commands/EditCommand.java
@@ -15,11 +15,11 @@ public class EditCommand implements CommandExecutor {
     @Override
     public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String @NotNull [] args) {
         if (!sender.hasPermission("discord.admin")){
-            sender.sendMessage("§cDu hast keine Berechtigung, diese Konfiguration zu bearbeiten.");
+            sender.sendMessage("§cYou dont have permissions to execute that command.");
             return false;
         }
         if (args.length < 2) {
-            sender.sendMessage("§cVerwendung: /discord config <key> <value>");
+            sender.sendMessage("§cUsage:: /discord config <key> <value>");
             return false;
         }
         String key = args[1];  // Der Konfigurations-Schlüssel
@@ -35,13 +35,13 @@ public class EditCommand implements CommandExecutor {
             plugin.saveConfig();
 
             // Erfolgsnachricht an den Sender senden
-            sender.sendMessage("§aDer Wert für " + key + " wurde auf " + value + " gesetzt und gespeichert!");
+            sender.sendMessage("§aThe value for " + key + " has been set to " + value + " and saved!");
 
             plugin.getServer().dispatchCommand(plugin.getServer().getConsoleSender(), "discord reload");
-            sender.sendMessage("§aDie Konfiguration wurde erfolgreich neu geladen.");
+            sender.sendMessage("§aThe config was reloaded.");
         } else {
             // Key existiert nicht -> Fehlermeldung
-            sender.sendMessage("§cUngültiger Key: '" + key + "'. Bitte wähle einen existierenden Schlüssel.");
+            sender.sendMessage("§cInvalid key: '" + key + "'. Please choose an existing key.");
         }
 
 

--- a/src/main/java/de/project_minecraft/commandDiscord/commands/HelpCommand.java
+++ b/src/main/java/de/project_minecraft/commandDiscord/commands/HelpCommand.java
@@ -41,29 +41,29 @@ public class HelpCommand implements CommandExecutor {
                 .append(Component.text("sir_melonchen")
                         .color(TextColor.color(0xFFFFFF))) // Weiß
                 .append(Component.text("\n\n"))
-                .append(Component.text("Befehle:\n")
+                .append(Component.text("Commands:\n")
                         .color(TextColor.color(0xFFFF00))) // Gelb
                 .append(Component.text("/discord reload")
                         .color(TextColor.color(0x00FFFF))) // Aqua
-                .append(Component.text(" - Lädt die Konfiguration neu")
+                .append(Component.text(" - Reloads the config")
                         .color(TextColor.color(0x808080))) // Grau
                 .append(Component.text("\n"))
                 .append(Component.text("/discord set <key> <value>")
                         .color(TextColor.color(0x00FFFF))) // Aqua
-                .append(Component.text(" - Setzt die Config")
+                .append(Component.text(" - Sets keys in the config")
                         .color(TextColor.color(0x808080))) // Grau
                 .append(Component.text("\n"))
                 .append(Component.text("/discord help")
                         .color(TextColor.color(0x00FFFF))) // Aqua
-                .append(Component.text(" - Zeigt diese Hilfe an")
+                .append(Component.text(" - Shows this page.")
                         .color(TextColor.color(0x808080))) // Grau
                 .append(Component.text("\n\n"))
-                .append(Component.text("Weitere Infos:\n")
+                .append(Component.text("More informations:\n")
                         .color(TextColor.color(0xFFFF00))) // Gelb
                 .append(Component.text("Website: ")
                         .color(TextColor.color(0x808080))) // Grau
                 .append(Component.text(website)
-                        .hoverEvent(HoverEvent.showText(Component.text("Klicke hier für die Website!")
+                        .hoverEvent(HoverEvent.showText(Component.text("Click here for the website!")
                                 .color(NamedTextColor.DARK_RED)
                                 .decorate(TextDecoration.BOLD)))
                         .clickEvent(ClickEvent.openUrl(website))

--- a/src/main/java/de/project_minecraft/commandDiscord/commands/ReloadCommand.java
+++ b/src/main/java/de/project_minecraft/commandDiscord/commands/ReloadCommand.java
@@ -17,7 +17,7 @@ public class ReloadCommand implements CommandExecutor {
     @Override
     public boolean onCommand(CommandSender sender, @NotNull Command command, @NotNull String label, String @NotNull [] args) {
         if (!sender.hasPermission("discord.admin")){
-            sender.sendMessage("§cDu hast keine Berechtigung, diese Konfiguration zu bearbeiten.");
+            sender.sendMessage("§cYou dont have permissions to execute that command.");
             return false;
         }
         plugin.reloadConfig();

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: DiscordCommand
 main: de.project_minecraft.commandDiscord.CommandDiscord
-version: 1.1 rev-3
+version: 1.1 rev-4
 authors:
   - sir_melonchen
 description: Ein Command der einen Discord-Link ausspuckt


### PR DESCRIPTION
Updated the commands to use English instead of German.  This includes updating permission messages, usage instructions, and help text.  The version number has also been bumped.