### PR TITLE
feat: Add task to print version (fix/gradecicommand)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,13 @@ tasks {
     }
 }
 
+tasks.register('printVersion') {
+    doLast {
+        println version
+    }
+}
+
+
 def targetJavaVersion = 21
 java {
     def javaVersion = JavaVersion.toVersion(targetJavaVersion)


### PR DESCRIPTION
Add a Gradle task to print the current project version. This allows for easy retrieval of the version number during the build process.